### PR TITLE
Update for OTP 19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Emakefile
 .dialyzer_plt
 .idea/
 *.iml
+.rebar

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ doc/edoc-info
 Emakefile
 *.bat
 .dialyzer_plt
+.idea/
+*.iml

--- a/include/ibrowse.hrl
+++ b/include/ibrowse.hrl
@@ -19,3 +19,9 @@
 -record(ibrowse_conf, {key, value}).
 
 -endif.
+
+-ifdef(deprecated_now).
+-define(NOW, timestamp).
+-else.
+-define(NOW, now).
+-endif.

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,8 @@
-{erl_opts, [debug_info, warnings_as_errors, warn_unused_vars, nowarn_shadow_vars, warn_unused_import]}.
+{erl_opts, [debug_info,
+            warnings_as_errors,
+            warn_unused_vars,
+            nowarn_shadow_vars,
+            warn_unused_import,
+            {platform_define, "(18|19|20)", deprecated_now}]}.
 {xref_checks, [undefined_function_calls, deprecated_function_calls]}.
 {eunit_opts, [verbose]}.

--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -433,7 +433,7 @@ accumulate_response(Data, #state{reply_buffer      = RepBuf,
 
 make_tmp_filename(true) ->
     DownloadDir = ibrowse:get_config_value(download_dir, filename:absname("./")),
-    {A,B,C} = erlang:timestamp(),
+    {A,B,C} = erlang:?NOW(),
     filename:join([DownloadDir,
                    "ibrowse_tmp_file_"++
                    integer_to_list(A) ++
@@ -1918,7 +1918,7 @@ cancel_timer(Ref, {eat_message, Msg}) ->
     end.
 
 make_req_id() ->
-    erlang:timestamp().
+    erlang:?NOW().
 
 to_lower(Str) when is_binary(Str) ->
     to_lower(binary_to_list(Str));

--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -433,7 +433,7 @@ accumulate_response(Data, #state{reply_buffer      = RepBuf,
 
 make_tmp_filename(true) ->
     DownloadDir = ibrowse:get_config_value(download_dir, filename:absname("./")),
-    {A,B,C} = now(),
+    {A,B,C} = erlang:timestamp(),
     filename:join([DownloadDir,
                    "ibrowse_tmp_file_"++
                    integer_to_list(A) ++
@@ -1918,7 +1918,7 @@ cancel_timer(Ref, {eat_message, Msg}) ->
     end.
 
 make_req_id() ->
-    now().
+    erlang:timestamp().
 
 to_lower(Str) when is_binary(Str) ->
     to_lower(binary_to_list(Str));

--- a/src/ibrowse_lib.erl
+++ b/src/ibrowse_lib.erl
@@ -368,7 +368,7 @@ default_port(ftp)   -> 21.
 
 printable_date() ->
     {{Y,Mo,D},{H, M, S}} = calendar:local_time(),
-    {_,_,MicroSecs} = now(),
+    {_,_,MicroSecs} = erlang:timestamp(),
     [integer_to_list(Y),
      $-,
      integer_to_list(Mo),

--- a/src/ibrowse_lib.erl
+++ b/src/ibrowse_lib.erl
@@ -368,7 +368,7 @@ default_port(ftp)   -> 21.
 
 printable_date() ->
     {{Y,Mo,D},{H, M, S}} = calendar:local_time(),
-    {_,_,MicroSecs} = erlang:timestamp(),
+    {_,_,MicroSecs} = erlang:?NOW(),
     [integer_to_list(Y),
      $-,
      integer_to_list(Mo),


### PR DESCRIPTION
This update is the for the preparation of new APNS API, which needs latest apns4erl and it requires at least OTP 19.